### PR TITLE
♻️ refactor(User): UserResponseCode 확장 (#4)

### DIFF
--- a/src/main/java/com/sparta/devquiz/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/devquiz/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package com.sparta.devquiz.domain.user.entity;
 
 import com.sparta.devquiz.domain.coin.entity.Coin;
 import com.sparta.devquiz.domain.quiz.entity.UserQuiz;
+import com.sparta.devquiz.domain.user.enums.OauthType;
 import com.sparta.devquiz.domain.user.enums.UserRole;
 import com.sparta.devquiz.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
@@ -35,21 +36,28 @@ public class User extends BaseTimeEntity {
     @Column(unique = true)
     private String oauthId;
 
-    @Column(nullable = false, length = 10, unique = true)
-    private String nickname;
+    @Column
+    @Enumerated(value = EnumType.STRING)
+    private OauthType oauthType;
+
+    @Column
+    private String password;
+
+    @Column(nullable = false, length = 30, unique = true)
+    private String username;
 
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private UserRole role;
 
     @Column(nullable = false)
-    private Long totalCoin = 0L;
+    private long totalCoin;
 
     @Column
     private LocalDateTime deletedAt;
 
     @Column(nullable = false)
-    private Boolean isDeleted = false;
+    private boolean isDeleted;
 
     @OneToMany(mappedBy = "user")
     private List<Skill> skillList = new ArrayList<>();

--- a/src/main/java/com/sparta/devquiz/domain/user/enums/OauthType.java
+++ b/src/main/java/com/sparta/devquiz/domain/user/enums/OauthType.java
@@ -1,0 +1,14 @@
+package com.sparta.devquiz.domain.user.enums;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OauthType {
+  GOOGLE("GOOGLE"),
+  GITHUB("GITHUB");
+
+  private final String type;
+}

--- a/src/main/java/com/sparta/devquiz/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/devquiz/domain/user/repository/UserRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByIdAndIsDeletedFalse(Long id);
   Optional<User> findByOauthIdAndIsDeletedFalse(String oauthId);
-  Optional<User> findByNicknameAndIsDeletedFalse(String nickname);
-  boolean existsByNickname(String nickname);
+  Optional<User> findByUsernameAndIsDeletedFalse(String username);
+  boolean existsByUsername(String username);
 }

--- a/src/main/java/com/sparta/devquiz/domain/user/response/UserResponseCode.java
+++ b/src/main/java/com/sparta/devquiz/domain/user/response/UserResponseCode.java
@@ -1,12 +1,14 @@
 package com.sparta.devquiz.domain.user.response;
 
+import com.sparta.devquiz.global.response.GlobalResponseCode;
+import com.sparta.devquiz.global.response.ResponseCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum UserResponseCode {
+public enum UserResponseCode implements ResponseCode {
 
     // OK 200
     OK(HttpStatus.OK, "REQUEST SUCCESS"),
@@ -34,5 +36,13 @@ public enum UserResponseCode {
 
     private final HttpStatus httpStatus;
     private final String message;
+
+    public HttpStatus getHttpStatus(GlobalResponseCode responseCode) {
+        return responseCode.getHttpStatus();
+    }
+
+    public String getMessage(GlobalResponseCode responseCode){
+        return responseCode.getMessage();
+    }
 
 }

--- a/src/main/java/com/sparta/devquiz/domain/user/response/UserResponseCode.java
+++ b/src/main/java/com/sparta/devquiz/domain/user/response/UserResponseCode.java
@@ -1,6 +1,5 @@
 package com.sparta.devquiz.domain.user.response;
 
-import com.sparta.devquiz.global.response.GlobalResponseCode;
 import com.sparta.devquiz.global.response.ResponseCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -37,11 +36,11 @@ public enum UserResponseCode implements ResponseCode {
     private final HttpStatus httpStatus;
     private final String message;
 
-    public HttpStatus getHttpStatus(GlobalResponseCode responseCode) {
+    public HttpStatus getHttpStatus(UserResponseCode responseCode) {
         return responseCode.getHttpStatus();
     }
 
-    public String getMessage(GlobalResponseCode responseCode){
+    public String getMessage(UserResponseCode responseCode){
         return responseCode.getMessage();
     }
 

--- a/src/main/java/com/sparta/devquiz/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/devquiz/domain/user/service/UserService.java
@@ -19,19 +19,19 @@ public class UserService {
     );
   }
 
-  public User getUserByOauthId(String oauthId) {
+  public User getOptUserByOauthId(String oauthId) {
     return userRepository.findByOauthIdAndIsDeletedFalse(oauthId).orElseThrow(
-            () -> new UserCustomException(UserExceptionCode.NOT_FOUND_USER)
+        () -> new UserCustomException(UserExceptionCode.NOT_FOUND_USER)
     );
   }
 
-  public User getUserByNickname(String nickname){
-    return userRepository.findByNicknameAndIsDeletedFalse(nickname).orElseThrow(
+  public User getUserByUsername(String nickname){
+    return userRepository.findByUsernameAndIsDeletedFalse(nickname).orElseThrow(
             () -> new UserCustomException(UserExceptionCode.NOT_FOUND_USER)
     );
   }
 
   public boolean isExistedNickname(String nickname){
-    return userRepository.existsByNickname(nickname);
+    return userRepository.existsByUsername(nickname);
   }
 }

--- a/src/main/java/com/sparta/devquiz/global/response/GlobalResponseCode.java
+++ b/src/main/java/com/sparta/devquiz/global/response/GlobalResponseCode.java
@@ -1,6 +1,5 @@
 package com.sparta.devquiz.global.response;
 
-import com.sparta.devquiz.domain.team.response.TeamResponseCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;


### PR DESCRIPTION
## 개요

- UserReponseCode 확장
- password, oauthType 컬럼 추가
- 기존 nickname 컬럼명 username으로 변경
- repository, service  메서드명 컬럼에 맞게 변경

## 작업사항

- [x]  responseCode 생성
- [x]  responseCode 각 DomainResponseCode에 implements
- [x]  DomainResponseCode에서 overriding

## 관련 이슈

- #4