### PR TITLE
🐛fix(Auth): reissue 시 refresh token도 재발급 처리 및 변수명 변경  (#24)

### DIFF
--- a/src/main/java/com/sparta/devquiz/domain/user/service/command/AuthService.java
+++ b/src/main/java/com/sparta/devquiz/domain/user/service/command/AuthService.java
@@ -1,8 +1,9 @@
 package com.sparta.devquiz.domain.user.service.command;
 
 import static com.sparta.devquiz.global.jwt.service.JwtService.ACCESS_COOKIE_NAME;
-import static com.sparta.devquiz.global.jwt.service.JwtService.ACCESS_COOKIE_TIME;
 import static com.sparta.devquiz.global.jwt.service.JwtService.REFRESH_COOKIE_NAME;
+import static com.sparta.devquiz.global.jwt.service.JwtService.COOKIE_TIME;
+import static com.sparta.devquiz.global.jwt.service.JwtService.REFRESH_JWT_TIME;
 
 import com.sparta.devquiz.global.jwt.service.JwtService;
 import com.sparta.devquiz.global.redis.RedisService;
@@ -42,7 +43,10 @@ public class AuthService {
 
       if (redisService.hasValues(oauthId) && refreshToken.equals(redisService.getValues(oauthId))) {
         String newAccessToken = jwtService.createAccessToken(oauthId, userRole);
-        jwtService.addToCookie(response, ACCESS_COOKIE_NAME, newAccessToken, ACCESS_COOKIE_TIME);
+        String newRefreshToken = jwtService.createRefreshToken(oauthId, userRole);
+        jwtService.addToCookie(response, ACCESS_COOKIE_NAME, newAccessToken, COOKIE_TIME);
+        jwtService.addToCookie(response, REFRESH_COOKIE_NAME, newRefreshToken, COOKIE_TIME);
+        redisService.setValues(oauthId, newRefreshToken.substring(7), REFRESH_JWT_TIME);
       }
     }
   }

--- a/src/main/java/com/sparta/devquiz/global/jwt/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/sparta/devquiz/global/jwt/filter/JwtAuthorizationFilter.java
@@ -35,7 +35,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    public void setAuthentication(String oauthId) {
+    private void setAuthentication(String oauthId) {
         SecurityContext context = SecurityContextHolder.createEmptyContext();
         Authentication authentication = createAuthentication(oauthId);
         context.setAuthentication(authentication);

--- a/src/main/java/com/sparta/devquiz/global/jwt/filter/JwtExceptionHandlerFilter.java
+++ b/src/main/java/com/sparta/devquiz/global/jwt/filter/JwtExceptionHandlerFilter.java
@@ -25,7 +25,7 @@ public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
       response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
-      CommonResponseDto result = new CommonResponseDto(e.getHttpStatus().value(), e.getMessage());
+      CommonResponseDto result = new CommonResponseDto(e.getHttpStatus().value(), e.getErrorCode());
       response.getWriter().write(new ObjectMapper().writeValueAsString(result));
     }
   }

--- a/src/main/java/com/sparta/devquiz/global/jwt/service/JwtService.java
+++ b/src/main/java/com/sparta/devquiz/global/jwt/service/JwtService.java
@@ -31,10 +31,9 @@ public class JwtService {
   public static final String AUTHORIZATION_KEY = "auth";
   public static final String ACCESS_COOKIE_NAME = "access_token";
   public static final int ACCESS_JWT_TIME  = 1 * 60 * 60 * 1000;
-  public static final int ACCESS_COOKIE_TIME = 1 * 60 * 60;
   public static final String REFRESH_COOKIE_NAME = "refresh_token";
   public static final int REFRESH_JWT_TIME = 7 * 24 * 60 * 60 * 1000;
-  public static final int REFRESH_COOKIE_TIME = 7 * 24 * 60 * 60;
+  public static final int COOKIE_TIME = 7 * 24 * 60 * 60;
 
   @Value("${jwt.secret.key}")
   private String secretKey;

--- a/src/main/java/com/sparta/devquiz/global/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/sparta/devquiz/global/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -1,9 +1,9 @@
 package com.sparta.devquiz.global.oauth.handler;
 
 import static com.sparta.devquiz.global.jwt.service.JwtService.ACCESS_COOKIE_NAME;
-import static com.sparta.devquiz.global.jwt.service.JwtService.ACCESS_COOKIE_TIME;
 import static com.sparta.devquiz.global.jwt.service.JwtService.REFRESH_COOKIE_NAME;
-import static com.sparta.devquiz.global.jwt.service.JwtService.REFRESH_COOKIE_TIME;
+import static com.sparta.devquiz.global.jwt.service.JwtService.COOKIE_TIME;
+import static com.sparta.devquiz.global.jwt.service.JwtService.REFRESH_JWT_TIME;
 import static com.sparta.devquiz.global.oauth.CookieUtil.REDIRECT_URI_COOKIE_NAME;
 
 import com.sparta.devquiz.global.jwt.dto.TokenSet;
@@ -36,8 +36,8 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     String targetUrl = determineTargetUrl(request, response, authentication);
     TokenSet tokenSet = createTokenSet(authentication);
 
-    jwtService.addToCookie(response, ACCESS_COOKIE_NAME, tokenSet.getAccessToken(), ACCESS_COOKIE_TIME);
-    jwtService.addToCookie(response, REFRESH_COOKIE_NAME, tokenSet.getRefreshToken(), REFRESH_COOKIE_TIME);
+    jwtService.addToCookie(response, ACCESS_COOKIE_NAME, tokenSet.getAccessToken(), COOKIE_TIME);
+    jwtService.addToCookie(response, REFRESH_COOKIE_NAME, tokenSet.getRefreshToken(), COOKIE_TIME);
 
     getRedirectStrategy().sendRedirect(request, response, targetUrl);
   }
@@ -58,7 +58,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
     TokenSet tokenSet = jwtService.createTokenSet(oauthId, authority);
 
-    redisService.setValues(oAuth2User.getName(), tokenSet.getRefreshToken().substring(7), REFRESH_COOKIE_TIME);
+    redisService.setValues(oAuth2User.getName(), tokenSet.getRefreshToken().substring(7), REFRESH_JWT_TIME);
 
     return tokenSet;
   }


### PR DESCRIPTION
## 개요

- reissue 서비스 로직 변경

## 작업사항

- refresh token도 재발급 설정
- 변수명 변경

## 관련 이슈
- #24