### PR TITLE
♻️ refactor(Auth): logout 시 Cookie 삭제 로직 변경 (#24)

### DIFF
--- a/src/main/java/com/sparta/devquiz/domain/user/controller/AuthController.java
+++ b/src/main/java/com/sparta/devquiz/domain/user/controller/AuthController.java
@@ -23,8 +23,8 @@ public class AuthController {
 
   @Operation(operationId = "AUTH-001", summary = "로그아웃")
   @PostMapping("/logout")
-  public ResponseEntity<CommonResponseDto> logout(HttpServletRequest request) {
-    authService.logout(request);
+  public ResponseEntity<CommonResponseDto> logout(HttpServletRequest request, HttpServletResponse response) {
+    authService.logout(request, response);
     return ResponseEntity.status(UserResponseCode.LOGOUT.getHttpStatus())
         .body(CommonResponseDto.of(UserResponseCode.LOGOUT));
   }


### PR DESCRIPTION
## 개요

- logout 서비스 로직 변경

## 작업사항

- logout 시 access, refresh token Cookie 삭제

## 관련 이슈
- #24